### PR TITLE
fix: building Python on MacOS

### DIFF
--- a/td-rs-xtask/xcode/project.pbxproj
+++ b/td-rs-xtask/xcode/project.pbxproj
@@ -591,7 +591,7 @@
 				<key>DEAD_CODE_STRIPPING</key>
 				<string>YES</string>
 				<key>FRAMEWORK_SEARCH_PATHS</key>
-				<string>/Applications/TouchDesigner.app/Contents/MacOS/TouchEngine.app/Contents/Frameworks</string>
+				<string>/Applications/TouchDesigner.app/Contents/Frameworks</string>
 				<key>INFOPLIST_FILE</key>
 				<string>$(SRCROOT)/Info.plist</string>
 				<key>INSTALL_PATH</key>
@@ -638,7 +638,7 @@
 				<key>DEAD_CODE_STRIPPING</key>
 				<string>YES</string>
 				<key>FRAMEWORK_SEARCH_PATHS</key>
-				<string>/Applications/TouchDesigner.app/Contents/MacOS/TouchEngine.app/Contents/Frameworks</string>
+				<string>/Applications/TouchDesigner.app/Contents/Frameworks</string>
 				<key>INFOPLIST_FILE</key>
 				<string>$(SRCROOT)/Info.plist</string>
 				<key>INSTALL_PATH</key>

--- a/td-rs.toml
+++ b/td-rs.toml
@@ -5,4 +5,4 @@ python_lib_dir = "C:\\Program Files\\Derivative\\TouchDesigner\\Samples\\CPlusPl
 
 [macos]
 plugin_folder = "$HOME/Library/Application Support/Derivative/TouchDesigner099/Plugins"
-python_include_dir = "/Applications/TouchDesigner.app/Contents/MacOS/TouchEngine.app/Contents/Frameworks/Python.framework/Headers"
+python_include_dir = "/Applications/TouchDesigner.app/Contents/Frameworks/Python.framework/Headers"


### PR DESCRIPTION
Not sure what's changed, maybe they've shuffled things around in TouchDesigner.app? Either way the build process couldn't find `Python.h` and this fixed it for me.

TD: 2023.12000
MacOS: Sonoma 14.3.1